### PR TITLE
fix bug requiring exact number of inputs

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -16,7 +16,7 @@ func Benchmark(b *testing.B, cs Cases, f Func) {
 	fv, _ := parseFuncs(f)
 
 	nIn := fv.Type().NumIn()
-	panicIf(nfc-1 != nIn, "Wrong number of input slices. Got %v, want %v.", nfc-1, nIn)
+	panicIf(nfc-1 < nIn, "Wrong number of inputs. Got %v, want %v.", nfc-1, nIn)
 
 	for i := 0; i < nc; i++ {
 		subbench(b, cvs.Index(i), fv, nIn)
@@ -25,6 +25,7 @@ func Benchmark(b *testing.B, cs Cases, f Func) {
 
 // subbench runs a sub-benchmark for the case cv using function fv.
 func subbench(b *testing.B, cv casev, fv funcv, nIn int) {
+    // Start from 1, since 0 is the label
 	inputs := sliceFrom(cv, 1, nIn)
 	b.Run(name(cv), func(b *testing.B) {
 		for k := 0; k < b.N; k++ {

--- a/cases.go
+++ b/cases.go
@@ -21,32 +21,38 @@ type Cases interface{}
 
 // parseCases converts cases reflect values and performs basic validation checks.
 // If any checks fail, parse panics.
+// nc is the number of cases, nf is the number of fields in a case (label + inputs + outputs)
 func parseCases(cs Cases) (cvs casesv, nc, nf int) {
 	cvs = reflect.ValueOf(cs)
 
+    // Ensure cs is a slice of cases.
 	kc := cvs.Kind()
 	panicIf(kc != reflect.Slice,
 		"Wrong kind of argument. Got %v, want %v.",
 		kc, "slice",
 	)
 
+    // Ensure there is at least 1 case.
 	nc = cvs.Len()
 	panicIf(nc == 0, "No cases.")
 
+    // Ensure each case is a struct.
 	kc = cvs.Type().Elem().Kind()
 	panicIf(kc != reflect.Struct,
 		"Wrong input type. Got []%v, want []%v",
 		kc, "struct",
 	)
 
+    // Ensure cases have at least 1 field, for the label.
 	nf = cvs.Index(0).NumField()
 	panicIf(nf == 0, "Empty cases.")
 
-	kc = cvs.Index(0).Field(0).Kind()
+    // Ensure the first field, the label, is a string.
+	kfc := cvs.Index(0).Field(0).Kind()
 	panicIf(
-		kc != reflect.String,
+		kfc != reflect.String,
 		"Wrong type for struct label. Got %v, want %v.",
-		kc, "string",
+		kfc, "string",
 	)
 
 	return


### PR DESCRIPTION
Benchmark required the number of fields nf to equal
the number of inputs ni + 1 (for the label). This meant
cases defining expected outputs could not be used.
The new condition is nf >= ni + 1, so now one set of cases
can be used for tests and benchmarks.

Also added some comments to helper functions to add clarity.